### PR TITLE
add support for nullable accessToken in send method and Envelope class

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -47,18 +47,25 @@ final class Client implements ClientInterface
         );
 
         $this->credential = $credential;
-        $this->logger = $logger === null ? new NullLogger() : $logger;
+        $this->logger = is_null($logger) ? new NullLogger() : $logger;
     }
 
-    public function send(string $templateId, string $channelId, Message $message): Response
+    public function send(?string $accessToken, string $templateId, string $channelId, Message $message): Response
     {
-        $this->getAccessToken();
+        // If accessToken is not provided, use the class's accessToken property
+        $token = $accessToken ?? $this->accessToken;
+
+        // Make sure to retrieve the token if it's still not set
+        if (!$token) {
+            $this->getAccessToken();  // Ensure token is available
+            $token = $this->accessToken;
+        }
 
         $response = $this->httpClient->post(
             'https://service-chat.qontak.com/api/open/v1/broadcasts/whatsapp/direct',
             [
                 'content-type' => 'application/json',
-                'Authorization' => \sprintf('Bearer %s', $this->accessToken ?? ''),
+                'Authorization' => \sprintf('Bearer %s', $token ?? ''),
             ],
             \json_encode(
                 [

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -8,5 +8,5 @@ use Inisiatif\WhatsappQontakPhp\Message\Message;
 
 interface ClientInterface
 {
-    public function send(string $templateId, string $channelId, Message $message): Response;
+    public function send(string $accessToken, string $templateId, string $channelId, Message $message): Response;
 }

--- a/src/Illuminate/Envelope.php
+++ b/src/Illuminate/Envelope.php
@@ -23,11 +23,22 @@ final class Envelope
      */
     private $message;
 
-    public function __construct(string $templateId, string $channelId, Message $message)
+    /**
+     * @var string|null
+     */
+    private $accessToken;
+
+    public function __construct(?string $accessToken, string $templateId, string $channelId, Message $message)
     {
+        $this->accessToken = $accessToken;
         $this->templateId = $templateId;
         $this->channelId = $channelId;
         $this->message = $message;
+    }
+
+    public function getAccessToken(): ?string
+    {
+        return $this->accessToken;
     }
 
     public function getTemplateId(): string

--- a/src/Illuminate/QontakChannel.php
+++ b/src/Illuminate/QontakChannel.php
@@ -26,6 +26,7 @@ final class QontakChannel
         $envelope = $notification->toQontak($notifiable);
 
         $this->client->send(
+            $envelope->getAccessToken(),
             $envelope->getTemplateId(),
             $envelope->getChannelId(),
             $envelope->getMessage()


### PR DESCRIPTION
feat: add support for nullable accessToken in send method and Envelope class

- Updated send method to handle nullable accessToken in ClientInterface implementation.
- Added accessToken handling in Envelope class and QontakChannel.
- Ensured compatibility with existing behavior when accessToken is not provided.
