### PR TITLE
bug: retry di QontakChannel tidak berhasil

### DIFF
--- a/src/Illuminate/QontakChannel.php
+++ b/src/Illuminate/QontakChannel.php
@@ -44,14 +44,16 @@ final class QontakChannel
                     // get delay from rate_limit_reset
                     $errorResponse = json_decode($e->getMessage(), true);
 
-                    if (isset($errorResponse['error']['messages'])) {
+                    if (isset($errorResponse['error']['messages']) && is_array($errorResponse['error']['messages'])) {
                         foreach ($errorResponse['error']['messages'] as $message) {
-                            if (strpos($message, 'rate_limit_reset:') === 0) {
+                            if (is_string($message) && str_starts_with($message, 'rate_limit_reset:')) {
                                 $delay = (int) trim(str_replace('rate_limit_reset:', '', $message));
                                 break;
                             }
                         }
                     }
+
+                    $delay = max(2, $delay + 2);
 
                     $notification->job->release($delay);
                     return;

--- a/src/Illuminate/QontakChannel.php
+++ b/src/Illuminate/QontakChannel.php
@@ -41,6 +41,18 @@ final class QontakChannel
                         $delay = $notification->getReleaseDelay();
                     }
 
+                    // get delay from rate_limit_reset
+                    $errorResponse = json_decode($e->getMessage(), true);
+
+                    if (isset($errorResponse['error']['messages'])) {
+                        foreach ($errorResponse['error']['messages'] as $message) {
+                            if (strpos($message, 'rate_limit_reset:') === 0) {
+                                $delay = (int) trim(str_replace('rate_limit_reset:', '', $message));
+                                break;
+                            }
+                        }
+                    }
+
                     $notification->job->release($delay);
                     return;
                 }

--- a/tests/QontakChannelTest.php
+++ b/tests/QontakChannelTest.php
@@ -63,7 +63,11 @@ final class QontakChannelTest extends TestCase
         'error' => [
           'code' => 429,
           'messages' => [
-            'Too many requests'
+            'Too many requests',
+            'organization_id: 01c228aa-381d-4b88-a0e4-8bb0ef10c7fe',
+            'rate_limit_limit: 100',
+            'rate_limit_remaining: 0',
+            'rate_limit_reset: 10'
           ],
         ]
       ]))
@@ -77,7 +81,8 @@ final class QontakChannelTest extends TestCase
     $client = new Client($credential, $httpClient);
 
     $mockJob = Mockery::mock(stdClass::class);
-    $mockJob->shouldReceive('release')->with(0)->once();
+    // rate_limit_reset + 2 = 12 seconds delay
+    $mockJob->shouldReceive('release')->with(12)->once();
 
     $notification = Mockery::mock(QontakNotification::class);
     $notification->job = $mockJob;


### PR DESCRIPTION
Error response dari Inisiatif\WhatsappQontakPhp\Exceptions\ClientSendingException: 

{"status":"error","error":{"code":429,"messages":["Too many requests","organization_id: 01c228aa-381d-4b88-a0e4-8bb0ef10c7fe","rate_limit_limit: 100","rate_limit_remaining: 0","rate_limit_reset: 10"]}}

dapat dilihat bahwa rate_limit_reset : 10
dan yang diset di getReleaseDelay biasanya : 5

jika api dihit kembali setelah delay 5, maka error rate_limit_masih terjadi. Harus menunggu rate_limit_reset mencapai angka 0 baru bisa di-hit kembali.

Maka, delay harus menyesuaikan dengan nilai dari rate_limit_reset